### PR TITLE
fix: drop fundament.css

### DIFF
--- a/webpage/templates/webpage/base.html
+++ b/webpage/templates/webpage/base.html
@@ -12,13 +12,6 @@
   <meta name="author" content="{{ metadata.author }}">
 {% endblock metaDescription %}
 
-{% block styles %}
-  <link rel="stylesheet"
-        id="fundament-styles"
-        href="{{ SHARED_URL }}fundament/dist/fundament/css/fundament.min.css"
-        type="text/css" />
-{% endblock styles %}
-
 {% block scriptHeader %}
   <!-- Begin Cookie Consent plugin by Silktide - https://silsktide.com/cookieconsent -->
   <script type="text/javascript">
@@ -127,7 +120,6 @@ _paq.push(['enableLinkTracking']);
 {% endblock userlogin-menu %}
 
 {% block scripts %}
-  <script src="{{ SHARED_URL }}fundament/dist/fundament/js/fundament.min.js"></script>
   <script type="text/javascript"
           src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.1/js/bootstrap-select.min.js"></script>
   <script src="{{ SHARED_URL }}apis/libraries/scroll-to-top/js/ap-scroll-top.min.js"></script>


### PR DESCRIPTION
The fundament code is buggy - there already was a problem with the
burger menu that is not visible on mobile devices and now the
<dialog> element is set to block by fundament, which makes it visible by
default. Fundament is not maintained upstream anymore, therefore we are
dropping the dependency.

Closes: #34
