### PR TITLE
fix: drop scripts block override

### DIFF
--- a/webpage/templates/webpage/base.html
+++ b/webpage/templates/webpage/base.html
@@ -119,12 +119,6 @@ _paq.push(['enableLinkTracking']);
   </ul>
 {% endblock userlogin-menu %}
 
-{% block scripts %}
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.1/js/bootstrap-select.min.js"></script>
-  <script src="{{ SHARED_URL }}apis/libraries/scroll-to-top/js/ap-scroll-top.min.js"></script>
-{% endblock scripts %}
-
 {% block imprint %}
   <div id="wrapper-footer-secondary"
        class="footer-imprint-bar p-2 text-center">


### PR DESCRIPTION
The scripts block in the base template overrides the one from the
base.html from apis-core to include bootstrap-select.min.js and
ap-scroll-top.min.js. Both those scripts are also part of the upstream
scripts block, which in addition also contains bootstrap.min.js.
Now (fcca28e2f8584dab954f93250e2bfb19e8b5048f) that apis-webage does not
contains fundament.js anymore and the block including bootstrap.min.js
is overridden, there is a javascript library missing.
The scripts override should therefore simply be dropped.

Closes: #37
